### PR TITLE
Fixing issues with deprication scipy

### DIFF
--- a/notebooks/lapnorm.py
+++ b/notebooks/lapnorm.py
@@ -13,6 +13,7 @@ from IPython.display import clear_output, Image, display, HTML
 import numpy as np
 import scipy.misc
 import tensorflow as tf
+import imageio
 
 
 #Create a session and load the Inception graph, then print the available layers.
@@ -133,6 +134,6 @@ def get_mask_sizes(init_size, oct_n, oct_s):
     return sizes
 
 def load_image(path, h, w):
-    img0 = scipy.misc.imread(path, mode='RGB')
-    img0 = scipy.misc.imresize(img0, (h, w)).astype('float64')
+    img0 = imageio.imread(path, as_gray=False, pilmode="RGB")
+    img0 = np.array(PIL.Image.fromarray(img0).resize((h, w))).astype('float64')
     return img0


### PR DESCRIPTION
the new paperspace ml in a box has updated the lastest scipy which depricates functions.

be sure to run pip install imageio to make sure you have the new package